### PR TITLE
UI/UX improvements + fixed typo in rate-limit verification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zoomies"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ anyhow = "1.0.76"
 inquire = "0.6.2"
 serde = { version = "1.0.193", features = ["derive"] }
 serde-xml-rs = "0.6.0"
+spinoff = "0.8.0"
 ureq = "2.9.1"
 win-beep = "1.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.76"
+colored = "2.1.0"
 inquire = "0.6.2"
 serde = { version = "1.0.193", features = ["derive"] }
 serde-xml-rs = "0.6.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,17 @@
-use inquire::{Text, CustomType, validator::Validation};
 use anyhow::Error;
+use inquire::{validator::Validation, CustomType, Text};
 use serde::Deserialize;
 use serde_xml_rs::from_str;
 use std::time::Duration;
-use ureq::{Agent, AgentBuilder};
 use std::{
     fs::File,
     io::{self, BufRead, BufReader},
     path::Path,
     thread::sleep,
 };
+use ureq::{Agent, AgentBuilder};
 
-pub const LOG_THRESHHOLD : i32 = 30;
+pub const LOG_THRESHHOLD: i32 = 30;
 
 macro_rules! log {
     ($level:ident, $($arg:tt)*) => (println!("[{}] {}", stringify!($level), format!($($arg)*)));
@@ -29,7 +29,7 @@ macro_rules! warn {
 struct Region {
     id: String,
     #[serde(alias = "LASTUPDATE")]
-    lastupdate : i32
+    lastupdate: i32,
 }
 
 // Yoinked from https://stackoverflow.com/questions/30801031/read-a-file-and-get-an-array-of-strings
@@ -49,33 +49,30 @@ fn get_last_update(agent: &Agent, region: &str) -> Result<Region, Error> {
         canonicalize(region)
     );
 
-    let response = agent
-        .get(&url)
-        .call()?
-        .into_string()?;
+    let response = agent.get(&url).call()?.into_string()?;
 
-    let response : Region = from_str(&response)?;
+    let response: Region = from_str(&response)?;
     Ok(response)
 }
 
-#[cfg(target_family="windows")]
-fn beep()
-{
+#[cfg(target_family = "windows")]
+fn beep() {
     win_beep::beep_with_hz_and_millis(800, 200);
 }
 
-#[cfg(target_family="unix")]
-fn beep()
-{
+#[cfg(target_family = "unix")]
+fn beep() {
     print!(r"\x07")
 }
 
 fn main() {
     // The validator used to ensure that the provided poll speed is valid
-    let validator = | input: &u64 | if input < &640 {
-        Ok(Validation::Invalid("Poll speed minimum is 650ms".into()))
-    } else {
-        Ok(Validation::Valid)
+    let validator = |input: &u64| {
+        if input < &640 {
+            Ok(Validation::Invalid("Poll speed minimum is 650ms".into()))
+        } else {
+            Ok(Validation::Valid)
+        }
     };
 
     println!(r" _  _______  _______  _______  _______ _________ _______  _______  _ ");
@@ -86,11 +83,9 @@ fn main() {
     println!(r"     /   /  | |   | || |   | || |   | |   | |   | (            ) |   ");
     println!(r"    /   (_/\| (___) || (___) || )   ( |___) (___| (____/\/\____) |   ");
     println!(r"   (_______/(_______)(_______)|/     \|\_______/(_______/\_______)   ");
-    println!("--===ᕕ( ᐛ )ᕗ");    
+    println!("--===ᕕ( ᐛ )ᕗ");
 
-    let main_nation = Text::new("Main Nation: ")
-        .prompt()
-        .unwrap();
+    let main_nation = Text::new("Main Nation: ").prompt().unwrap();
 
     let poll_speed = CustomType::new("Poll Speed (Min 650): ")
         .with_validator(validator)
@@ -112,56 +107,45 @@ fn main() {
         .expect("trigger_list.txt did not exist. Consult README.md for template.");
 
     sleep(Duration::from_millis(poll_speed));
-    let lu_banana = get_last_update(&api_agent, "banana")
-        .unwrap();
+    let lu_banana = get_last_update(&api_agent, "banana").unwrap();
     sleep(Duration::from_millis(poll_speed));
-    let lu_wzt = get_last_update(&api_agent, "warzone trinidad")
-        .unwrap();
-    let update_running : bool = lu_banana.lastupdate > lu_wzt.lastupdate;
+    let lu_wzt = get_last_update(&api_agent, "warzone trinidad").unwrap();
+    let update_running: bool = lu_banana.lastupdate > lu_wzt.lastupdate;
 
     // Fetch and sort trigger data
-    let sort_time = ((triggers.len() as u64) * poll_speed)/1000;
+    let sort_time = ((triggers.len() as u64) * poll_speed) / 1000;
     info!("Sorting triggers. This will take ~{} seconds.", sort_time);
-    let mut trigger_data : Vec<Region> = Vec::new();
-    for trigger in triggers
-    {
+    let mut trigger_data: Vec<Region> = Vec::new();
+    for trigger in triggers {
         sleep(Duration::from_millis(poll_speed));
-        match get_last_update(&api_agent, &trigger)
-        {
+        match get_last_update(&api_agent, &trigger) {
             Ok(region) => {
-                if update_running && lu_banana.lastupdate < region.lastupdate
-                {
+                if update_running && lu_banana.lastupdate < region.lastupdate {
                     warn!("{} has already updated.", region.id);
-                }
-                else
-                {
+                } else {
                     trigger_data.push(region)
                 }
-            },
-            Err(_) => warn!("Could not fetch Last Update data for {}.", trigger)
+            }
+            Err(_) => warn!("Could not fetch Last Update data for {}.", trigger),
         }
     }
-    trigger_data.sort_by(| a, b | a.lastupdate.cmp(&b.lastupdate) );
+    trigger_data.sort_by(|a, b| a.lastupdate.cmp(&b.lastupdate));
     info!("Triggers sorted.");
 
     let banner = "*".repeat(15);
-    for trigger in trigger_data
-    {
+    for trigger in trigger_data {
         info!("Waiting for {}", trigger.id);
-        let updated : bool = false;
-        while !updated
-        {
+        let updated: bool = false;
+        while !updated {
             sleep(Duration::from_millis(poll_speed));
-            match get_last_update(&api_agent, &trigger.id)
-            {
+            match get_last_update(&api_agent, &trigger.id) {
                 Ok(region) => {
-                    if region.lastupdate != trigger.lastupdate
-                    {
+                    if region.lastupdate != trigger.lastupdate {
                         beep();
                         println!("{}\n{} HAS UPDATED\n{}", banner, region.id, banner);
                     }
                 }
-                Err(_) => warn!("Fetch failed!")
+                Err(_) => warn!("Fetch failed!"),
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,7 @@ fn main() {
         .unwrap();
 
     let user_agent = format!(
-        "Zoomies/{0} (Developed by nation=Vleerian; In use by nation={1})",
+        "Zoomies/{0} (Developed by nation=Vleerian and nation=Volstrostia; In use by nation={1})",
         env!("CARGO_PKG_VERSION"),
         main_nation
     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use anyhow::Error;
+use colored::Colorize;
 use inquire::{validator::Validation, CustomType, Text};
 use serde::Deserialize;
 use serde_xml_rs::from_str;
@@ -161,7 +162,7 @@ fn main() {
                     if region.lastupdate != trigger.lastupdate {
                         beep();
                         // println!("{}\n{} HAS UPDATED\n{}", banner, region.id, banner);
-                        let success_msg = format!("{} HAS UPDATED", region.id);
+                        let success_msg = format!("UPDATE DETECTED IN {}", region.id.to_uppercase()).green().bold();
                         spinner.success(&success_msg);
                         break;
                     }


### PR DESCRIPTION
Fixed bug that forced it to focus on one trigger forever
Fixed typo that allowed minimum rate-limit of 640ms instead of 650ms
Changed output to use spinners
Added check to create a trigger_list.txt if not present
Ran codebase through cargo fmt
